### PR TITLE
Upgrading JSON.NET and adding some error handing

### DIFF
--- a/src/Freightview.ApiClient/ApiClient.cs
+++ b/src/Freightview.ApiClient/ApiClient.cs
@@ -1,16 +1,23 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Formatting;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace Freightview.ApiClient
 {
 	public class ApiClient
 	{
+		public List<MediaTypeFormatter> formatters { get; private set; }
 		public ApiClient(HttpClient apiClient)
 		{
 			this.Client = apiClient;
+			this.formatters = new List<MediaTypeFormatter>();
+			this.formatters.Add(new JsonMediaTypeFormatter() {SerializerSettings = new Newtonsoft.Json.JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore}});
+			this.formatters.Add(new XmlMediaTypeFormatter());
 		}
 
 		protected HttpClient Client { get; set; }
@@ -34,19 +41,18 @@ namespace Freightview.ApiClient
 		protected async Task<T> HandleResponse<T>(HttpResponseMessage response)
 		{
 			await CheckErrors(response);
-			return await response.Content.ReadAsAsync<T>();
+			return await response.Content.ReadAsAsync<T>(formatters);
 		}
 		protected async Task HandleResponse(HttpResponseMessage response)
 		{
 			await CheckErrors(response);
 		}
-
 		protected async Task HandleError(HttpResponseMessage response)
 		{
 			Exception err = null;
 			try
 			{
-				var error = await response.Content.ReadAsAsync<ErrorResponse>();
+				var error = await response.Content.ReadAsAsync<ErrorResponse>(formatters);
 				err = new ApiException(error);
 			}
 			catch {} //failed parsing content as ErrorResponse; ignore and just read all the content 
@@ -54,12 +60,11 @@ namespace Freightview.ApiClient
 			if (err == null)
 			{
 				var content = await response.Content.ReadAsStringAsync();
-				err = new ApplicationException(content);
+				err = new ApplicationException(string.Format("API response status code: {0} {1}; {2}", (int)response.StatusCode, response.StatusCode, content));
 			}
 
 			throw err;
 		}
-
 		public async Task<RatesResponse> GetRates(RatesRequest ratesRequest)
 		{
 			var response = await Client.PostAsJsonAsync("rates", ratesRequest);

--- a/src/Freightview.ApiClient/App.config
+++ b/src/Freightview.ApiClient/App.config
@@ -1,16 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
-    </startup>
-
+	<startup>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+	</startup>
 	<runtime>
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
 				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
 			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>
-
 </configuration>

--- a/src/Freightview.ApiClient/Freightview.ApiClient.csproj
+++ b/src/Freightview.ApiClient/Freightview.ApiClient.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Freightview.ApiClient/Program.cs
+++ b/src/Freightview.ApiClient/Program.cs
@@ -26,13 +26,14 @@ namespace Freightview.ApiClient
 			//basic boiler plate to setup an HTTP client with authorization headers included automatically
 			var utf8 = new System.Text.UTF8Encoding(false, false);
 			var http = new HttpClient();
-//			http.BaseAddress = new Uri("http://10.211.55.2:3001/api/v1/"); //our local dev
-			http.BaseAddress = new Uri("https://www.freightview.com/api/v1/");
+//			http.BaseAddress = new Uri("http://192.168.12.1:3001/api/v1.0/"); //our local dev
+//			http.BaseAddress = new Uri("http://10.211.55.2:3001/api/v1.0/"); //our local dev
+			http.BaseAddress = new Uri("https://www.freightview.com/api/v1.0/");
 
 			//Auth header is username:password. For ours use: "api-key:"
 			//You should probably pull this from a secure config
 			//TODO: Change this to use your API credential; don't forget the ending `:`
-			var credentials = "14b50208901be261144a8b217e84821b7da835128cb:"; 
+			var credentials = "1508ade3c6e255be5d75e5d37c7fc94525a2abd5cf7:";
 
 			//set the default AUTH header on all calls using this HTTPClient
 			http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(utf8.GetBytes(credentials)));

--- a/src/Freightview.ApiClient/packages.config
+++ b/src/Freightview.ApiClient/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
 </packages>

--- a/src/Freightview.ApiClientTests/Freightview.ApiClientTests.csproj
+++ b/src/Freightview.ApiClientTests/Freightview.ApiClientTests.csproj
@@ -35,8 +35,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Freightview.ApiClientTests/Setup.cs
+++ b/src/Freightview.ApiClientTests/Setup.cs
@@ -16,14 +16,17 @@ namespace Freightview.ApiClientTests
 
 			var http = new HttpClient();
 
-            //Local dev testing:
-            //VMWare Fusion: "http://172.16.174.1:3001/api/v1/"
-            //Parallels: "http://10.211.55.2:3001/api/v1/"
-            http.BaseAddress = new Uri("https://www.freightview.com/api/v1");
+			//Local dev testing:
+			//VMWare Fusion:
+//			http.BaseAddress = new Uri("http://192.168.12.1:3001/api/v1.0/");
+			//Parallels: 
+//			http.BaseAddress = new Uri("http://10.211.55.2:3001/api/v1.0/");
+			//Production
+			http.BaseAddress = new Uri("https://www.freightview.com/api/v1.0");
 
-            //Repace this header with your own API key. 
+			//TODO: Repace this header with your own API key. 
 			//Auth header is username:password. For ours use: "api-key:"
-            var credentials = "1506208f5dfc2147cd0bde58e9e05fb81539e0f5c13:"; //pull this from a secure config
+			var credentials = "1508ade3c6e255be5d75e5d37c7fc94525a2abd5cf7:";
 			if (!string.IsNullOrWhiteSpace(credentials))
 				http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(utf8.GetBytes(credentials)));
 

--- a/src/Freightview.ApiClientTests/app.config
+++ b/src/Freightview.ApiClientTests/app.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
+	<runtime>
+		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+			</dependentAssembly>
+		</assemblyBinding>
+	</runtime>
 </configuration>

--- a/src/Freightview.ApiClientTests/packages.config
+++ b/src/Freightview.ApiClientTests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- Updated JSON.net to 8.0 from 7.0 along with binding redirects
- Fixed API endpoints to include officially documented `v1.0` endpoints
- Added custom formatters to handle null property responses in the JSON serializer (as an example)
- Added more detailed error output when encountering operational exceptions (non 200 responses, connection problems, etc).
